### PR TITLE
Change base url

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -17,7 +17,7 @@ module.exports = {
   title:
     'Easy to use set of tools to create on-device ML demos on Android and iOS. Unlock the vast potential of AI innovations.',
   url: 'https://pytorch.org/live',
-  baseUrl: '/',
+  baseUrl: '/live/',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.ico',


### PR DESCRIPTION
Summary: Change base url for PyTorch Live website to reflect sub path on pytorch.org/live.

Reviewed By: williamngan

Differential Revision: D32763207

