### PR TITLE
RuntimeError related to quantization solved for ARM architecture

### DIFF
--- a/react-native-template-pytorch-live/template/models/make_models.py
+++ b/react-native-template-pytorch-live/template/models/make_models.py
@@ -7,6 +7,7 @@ import tempfile
 import urllib
 import zipfile
 from pathlib import Path
+import platform
 
 import torch
 import torchvision
@@ -17,6 +18,8 @@ print(f"torch version {torch.__version__}")
 
 MODEL_EXTENSION = "ptl"
 
+if platform.processor() == 'arm' or platform.processor() == 'i386':
+    torch.backends.quantized.engine = 'qnnpack'
 
 def bundle_live_spec_and_export_model(name: str, model):
     optimized_model = optimize_for_mobile(model)


### PR DESCRIPTION
## Summary

When we tried to build the models with the `python3 make_models.py` command from the MacBooks with Apple Silicon, we got the following RuntimeError:
```bash
RuntimeError: Didn't find engine for operation quantized::linear_prepack NoQEngine
```

This error occurs because `fbgemm` backend is enabled by default as it works well with x86 CPUs ([PyTorch natively supported backends](https://pytorch.org/docs/stable/quantization.html#natively-supported-backends)). However, ARM CPUs only work when the `qnnpack` backend engine is enabled. This is the reason why in this PR `qnnpack` is only used when working with ARM CPUs (`arm` or `i386`).


## Changelog

[TEMPLATE] [APPLE SILICON] - RuntimeError related to quantization solved for ARM architecture

## Test Plan

The following is the command I use to create the project with your local template (Substitute `Users/aaron/Documents/github` by your absolute address to your current working directory):
```bash
npx react-native init LiveM1Test --template file://Users/aaron/Documents/github/live/react-native-template-pytorch-live/
```

Go to the `models` directory (`cd LiveM1Test/models/ `), activate the virtual environment (`source venv/bin/activate`) and install the dependencies if they are not installed once the virtual environment has been activated:

```bash
python3 -m pip install -r requirements.txt --no-cache-dir
```

---

### Before

Result of `python3 -W ignore make_models.py`:

![B0CE294E-B67D-4E3B-88C6-E28DE948BFA2](https://user-images.githubusercontent.com/39239895/144952720-4b5e7044-059f-4259-bd14-84847dd590e5.jpeg)

---

### After

Result of `python3 -W ignore make_models.py`:

![E27B0E6F-A3F2-41E8-846F-7CE494A9024B_4_5005_c](https://user-images.githubusercontent.com/39239895/144952858-1122cc55-72ad-4cd7-a948-e6dcb0b9f799.jpeg)




