### PR TITLE
Adding GH action config as website deploy trigger

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -4,11 +4,13 @@ on:
   push:
     branches: [main]
     paths:
+      - '.github/workflows/deploy-website.yml'
       - 'website/**'
       - 'react-native-pytorch-core/src/**'
   pull_request:
     branches: [main]
     paths:
+      - '.github/workflows/deploy-website.yml'
       - 'website/**'
       - 'react-native-pytorch-core/src/**'
 


### PR DESCRIPTION
## Summary

The website deploy GitHub Action doesn't have a manual trigger, but triggers automatically when any of the following paths change:

* `website/**`
* `react-native-pytorch-core/src/**`

However, the website deploy GitHub Action does not trigger when the `deploy-website.yml` config changes. It can be useful to also trigger the action itself when this file changes, e.g., when upgrading node versions or updating GitHub Action plugins, etc.

This change adds the website deploy GitHub action config to the watched paths.

## Changelog

Add `.github/workflows/deploy-website.yml` to watched paths that trigger the website deploy GitHub action.

[CATEGORY] [TYPE] - Message

## Test Plan

Tested in forked repo `raedle/live`. The website deploy GitHub action ran successfully after making a change to the `website-deploy.yml` configuration.

Test run: https://github.com/raedle/live/actions/runs/1564539703

![image](https://user-images.githubusercontent.com/489051/145619237-c0a372cf-423c-4054-91a5-4b94d5924b5b.png)