### PR TITLE
Create an AVD for the M1 Macs (avoids emulator failure)

### DIFF
--- a/torchlive-cli/src/android/AndroidSDK.ts
+++ b/torchlive-cli/src/android/AndroidSDK.ts
@@ -164,3 +164,7 @@ export function isPackageInstalled(filePath: string): boolean {
   const packages = getInstalledPackages();
   return packages.findIndex(pkg => pkg.path === filePath) > -1;
 }
+
+export function getAndroidEmulatorABI(): string {
+  return os.cpus()[0].model.startsWith('Apple M') ? 'arm64-v8a' : 'x86_64';
+}

--- a/torchlive-cli/src/android/AndroidSDK.ts
+++ b/torchlive-cli/src/android/AndroidSDK.ts
@@ -166,5 +166,11 @@ export function isPackageInstalled(filePath: string): boolean {
 }
 
 export function getAndroidEmulatorABI(): string {
-  return os.cpus()[0].model.startsWith('Apple M') ? 'arm64-v8a' : 'x86_64';
+  switch (process.platform) {
+    case 'darwin':
+      return os.cpus()[0].model.startsWith('Apple M') ? 'arm64-v8a' : 'x86_64';
+    case 'linux':
+    case 'win32':
+      return os.arch() === 'arm' || 'arm64' ? 'arm64-v8a' : 'x86_64';
+  }
 }

--- a/torchlive-cli/src/cli-commands/Doctor.ts
+++ b/torchlive-cli/src/cli-commands/Doctor.ts
@@ -11,6 +11,7 @@ import chalk from 'chalk';
 import {Command} from 'commander';
 import execa from 'execa';
 import semver from 'semver';
+import os from 'os';
 import {getInstalledPackages, Package} from '../android/AndroidSDK';
 import avdManager from '../commands/android/AVDManager';
 import emulator from '../commands/android/Emulator';
@@ -144,6 +145,7 @@ function runHealthCheck(healthCheck: IHealthCheck, ind: number = 2): void {
 
 const runDoctor = async (): Promise<void> => {
   printHeader();
+  const abi = os.cpus()[0].model === 'Apple M1' ? 'arm64-v8a' : 'x86_64';
 
   const healthChecks: IHealthCheck[] = [
     new HealthCheck('Homebrew', homebrew, {
@@ -185,7 +187,7 @@ const runDoctor = async (): Promise<void> => {
           path: 'platforms;android-29',
         },
         {
-          path: 'system-images;android-29;google_apis;x86_64',
+          path: `system-images;android-29;google_apis;${abi}`,
         },
       ],
       parseInstalledPackages(): Package[] {

--- a/torchlive-cli/src/cli-commands/Doctor.ts
+++ b/torchlive-cli/src/cli-commands/Doctor.ts
@@ -11,8 +11,11 @@ import chalk from 'chalk';
 import {Command} from 'commander';
 import execa from 'execa';
 import semver from 'semver';
-import os from 'os';
-import {getInstalledPackages, Package} from '../android/AndroidSDK';
+import {
+  getInstalledPackages,
+  getAndroidEmulatorABI,
+  Package,
+} from '../android/AndroidSDK';
 import avdManager from '../commands/android/AVDManager';
 import emulator from '../commands/android/Emulator';
 import sdkManager from '../commands/android/SDKManager';
@@ -145,7 +148,7 @@ function runHealthCheck(healthCheck: IHealthCheck, ind: number = 2): void {
 
 const runDoctor = async (): Promise<void> => {
   printHeader();
-  const abi = os.cpus()[0].model === 'Apple M1' ? 'arm64-v8a' : 'x86_64';
+  const abi = getAndroidEmulatorABI();
 
   const healthChecks: IHealthCheck[] = [
     new HealthCheck('Homebrew', homebrew, {

--- a/torchlive-cli/src/installers/android/AbstractAndroidCommandLineTools.ts
+++ b/torchlive-cli/src/installers/android/AbstractAndroidCommandLineTools.ts
@@ -9,6 +9,7 @@
 
 import path from 'path';
 import {getSDKPath} from '../../android/AndroidSDK';
+import os from 'os';
 
 export default abstract class AbstractAndroidCommandLineTools {
   private commandLineTool: string;
@@ -23,5 +24,9 @@ export default abstract class AbstractAndroidCommandLineTools {
       throw new Error('no Android SDK found');
     }
     return path.join(sdkPath, this.commandLineTool);
+  }
+
+  getAbi(): string {
+    return os.cpus()[0].model === 'Apple M1' ? 'arm64-v8a' : 'x86_64';
   }
 }

--- a/torchlive-cli/src/installers/android/AbstractAndroidCommandLineTools.ts
+++ b/torchlive-cli/src/installers/android/AbstractAndroidCommandLineTools.ts
@@ -9,7 +9,6 @@
 
 import path from 'path';
 import {getSDKPath} from '../../android/AndroidSDK';
-import os from 'os';
 
 export default abstract class AbstractAndroidCommandLineTools {
   private commandLineTool: string;
@@ -24,9 +23,5 @@ export default abstract class AbstractAndroidCommandLineTools {
       throw new Error('no Android SDK found');
     }
     return path.join(sdkPath, this.commandLineTool);
-  }
-
-  getAbi(): string {
-    return os.cpus()[0].model === 'Apple M1' ? 'arm64-v8a' : 'x86_64';
   }
 }

--- a/torchlive-cli/src/installers/android/AndroidEmulatorDeviceInstaller.ts
+++ b/torchlive-cli/src/installers/android/AndroidEmulatorDeviceInstaller.ts
@@ -65,8 +65,8 @@ export default class AndroidEmulatorDeviceInstaller
       return;
     }
     const cltPath = this.getCommandLineToolPath();
+    const abi = this.getAbi();
     context.update(`Setting up ${this.getDescription()}`);
-    const abi = os.cpus()[0].model === 'Apple M1' ? 'arm64-v8a' : 'x86_64';
     const cmd = `echo "no" | ${cltPath} create avd --name "${AndroidVirtualDeviceName}" --device "pixel" --force --abi google_apis/${abi} --package "system-images;android-29;google_apis;${abi}"`;
     await execCommand(context, cmd);
 

--- a/torchlive-cli/src/installers/android/AndroidEmulatorDeviceInstaller.ts
+++ b/torchlive-cli/src/installers/android/AndroidEmulatorDeviceInstaller.ts
@@ -20,6 +20,7 @@ import {
   getInstallerErrorMitigationMessage,
 } from '../IInstaller';
 import cliPkgInfo from '../../../package.json';
+import {getAndroidEmulatorABI} from '../../android/AndroidSDK';
 
 export default class AndroidEmulatorDeviceInstaller
   extends AbstractAndroidCommandLineTools
@@ -65,7 +66,7 @@ export default class AndroidEmulatorDeviceInstaller
       return;
     }
     const cltPath = this.getCommandLineToolPath();
-    const abi = this.getAbi();
+    const abi = getAndroidEmulatorABI();
     context.update(`Setting up ${this.getDescription()}`);
     const cmd = `echo "no" | ${cltPath} create avd --name "${AndroidVirtualDeviceName}" --device "pixel" --force --abi google_apis/${abi} --package "system-images;android-29;google_apis;${abi}"`;
     await execCommand(context, cmd);

--- a/torchlive-cli/src/installers/android/AndroidEmulatorDeviceInstaller.ts
+++ b/torchlive-cli/src/installers/android/AndroidEmulatorDeviceInstaller.ts
@@ -66,7 +66,8 @@ export default class AndroidEmulatorDeviceInstaller
     }
     const cltPath = this.getCommandLineToolPath();
     context.update(`Setting up ${this.getDescription()}`);
-    const cmd = `echo "no" | ${cltPath} create avd --name "${AndroidVirtualDeviceName}" --device "pixel" --force --abi google_apis/x86_64 --package "system-images;android-29;google_apis;x86_64"`;
+    const abi = os.cpus()[0].model === 'Apple M1' ? 'arm64-v8a' : 'x86_64';
+    const cmd = `echo "no" | ${cltPath} create avd --name "${AndroidVirtualDeviceName}" --device "pixel" --force --abi google_apis/${abi} --package "system-images;android-29;google_apis;${abi}"`;
     await execCommand(context, cmd);
 
     const configPath = this._getConfigPath();
@@ -75,7 +76,7 @@ export default class AndroidEmulatorDeviceInstaller
     config = Object.assign(config, {
       'torchlive.cli.version': cliPkgInfo.version,
       'PlayStore.enabled': false,
-      'abi.type': 'x86_64',
+      'abi.type': abi,
       'avd.ini.encoding': 'UTF-8',
       'disk.dataPartition.size': '16G',
       'fastboot.chosenSnapshotFile': '',
@@ -88,7 +89,7 @@ export default class AndroidEmulatorDeviceInstaller
       'hw.battery': 'yes',
       'hw.camera.back': 'webcam0',
       'hw.camera.front': 'webcam0',
-      'hw.cpu.arch': 'x86_64',
+      'hw.cpu.arch': abi,
       'hw.dPad': 'no',
       'hw.device.hash2': 'MD5:6b5943207fe196d842659d2e43022e20',
       'hw.device.manufacturer': 'Google',

--- a/torchlive-cli/src/installers/android/AndroidEmulatorDeviceInstaller.ts
+++ b/torchlive-cli/src/installers/android/AndroidEmulatorDeviceInstaller.ts
@@ -89,7 +89,7 @@ export default class AndroidEmulatorDeviceInstaller
       'hw.battery': 'yes',
       'hw.camera.back': 'webcam0',
       'hw.camera.front': 'webcam0',
-      'hw.cpu.arch': abi,
+      'hw.cpu.arch': abi === 'arm64-v8a' ? 'arm64' : 'x86_64',
       'hw.dPad': 'no',
       'hw.device.hash2': 'MD5:6b5943207fe196d842659d2e43022e20',
       'hw.device.manufacturer': 'Google',

--- a/torchlive-cli/src/installers/android/AndroidSDKManagerInstaller.ts
+++ b/torchlive-cli/src/installers/android/AndroidSDKManagerInstaller.ts
@@ -38,6 +38,7 @@ export default class AndroidSDKManagerInstaller
 
   isInstalled(): boolean {
     const sdkPath = getSDKPath();
+    const abi = this.getAbi();
     return (
       sdkPath != null &&
       fs.existsSync(path.join(sdkPath, 'tools')) &&
@@ -46,7 +47,7 @@ export default class AndroidSDKManagerInstaller
       isPackageInstalled('emulator') &&
       isPackageInstalled('platform-tools') &&
       isPackageInstalled('platforms;android-29') &&
-      isPackageInstalled('system-images;android-29;google_apis;x86_64')
+      isPackageInstalled(`system-images;android-29;google_apis;${abi}`)
     );
   }
 
@@ -60,6 +61,7 @@ export default class AndroidSDKManagerInstaller
   async run(context: TaskContext): Promise<void> {
     const sdkPath = getSDKPath();
     const cltPath = this.getCommandLineToolPath();
+    const abi = this.getAbi();
 
     context.update('Setting up ~/.android/repositories.cfg');
 
@@ -98,11 +100,11 @@ export default class AndroidSDKManagerInstaller
       'platforms;android-29',
     ]);
 
-    context.update('Installing system-images;android-29;google_apis;x86_64');
+    context.update(`Installing system-images;android-29;google_apis;${abi}`);
 
     await spawnCommand(context, cltPath, [
       `--sdk_root=${sdkPath}`,
-      'system-images;android-29;google_apis;x86_64',
+      `system-images;android-29;google_apis;${abi}`,
     ]);
   }
 }

--- a/torchlive-cli/src/installers/android/AndroidSDKManagerInstaller.ts
+++ b/torchlive-cli/src/installers/android/AndroidSDKManagerInstaller.ts
@@ -19,6 +19,7 @@ import {
   getUserConsentOnInstallerOrQuit,
 } from '../IInstaller';
 import AbstractAndroidCommandLineTools from './AbstractAndroidCommandLineTools';
+import {getAndroidEmulatorABI} from '../../android/AndroidSDK';
 
 export default class AndroidSDKManagerInstaller
   extends AbstractAndroidCommandLineTools
@@ -38,7 +39,7 @@ export default class AndroidSDKManagerInstaller
 
   isInstalled(): boolean {
     const sdkPath = getSDKPath();
-    const abi = this.getAbi();
+    const abi = getAndroidEmulatorABI();
     return (
       sdkPath != null &&
       fs.existsSync(path.join(sdkPath, 'tools')) &&
@@ -61,7 +62,7 @@ export default class AndroidSDKManagerInstaller
   async run(context: TaskContext): Promise<void> {
     const sdkPath = getSDKPath();
     const cltPath = this.getCommandLineToolPath();
-    const abi = this.getAbi();
+    const abi = getAndroidEmulatorABI();
 
     context.update('Setting up ~/.android/repositories.cfg');
 


### PR DESCRIPTION
## Summary

> The purpose of this pull request is to also create an AVD for the ARM architecture in order to adapt TorchLive for the M1 Macs.

We can see that the file [AndroidEmulatorDeviceInstaller.ts](https://github.com/pytorch/live/blob/main/torchlive-cli/src/installers/android/AndroidEmulatorDeviceInstaller.ts) will create a x86 Android Emulator:

Previous command to create the AVD:

```jsx
const cmd = `echo "no" | ${cltPath} create avd --name "${AndroidVirtualDeviceName}" --device "pixel" --force --abi google_apis/x86_64 --package "system-images;android-29;google_apis;x86_64"`;
```

Previous keys in the config.ini file of the `pytorch_live` device:

```jsx
'abi.type': 'x86_64',
'hw.cpu.arch': 'x86_64',
```

When we execute the command `npx torchlive-cli setup-dev` we don't get an error but instead an unusable AVD is created (see that the PyTorch Live AVD has a size of just 1MB):

<img width="1218" alt="Screenshot_2022-01-02_at_18 07 06" src="https://user-images.githubusercontent.com/39239895/147962859-8ee8ea9a-a234-4077-919d-27a089b1c360.png">

Therefore, if we execute the command `npx torchlive-cli run-android` the terminal will print the android emulator version but it won't continue the execution as it can't execute a device designed to be executed in a x86 CPU architecture:

<img width="509" alt="Screenshot_2022-01-03_at_18 34 46" src="https://user-images.githubusercontent.com/39239895/147962881-58b0c01f-57fd-4931-8cba-dd25a5d4c285.png">

Things that were done to make this adaptation possible:

- Download the right system image depending on the CPU architecture ([AndroidSDKManagerInstaller.ts](https://github.com/pytorch/live/blob/main/torchlive-cli/src/installers/android/AndroidSDKManagerInstaller.ts) file).
- Create the correct AVD depending on the CPU architecture ([AndroidEmulatorDeviceInstaller.ts](https://github.com/pytorch/live/blob/main/torchlive-cli/src/installers/android/AndroidEmulatorDeviceInstaller.ts) file).
- Change the config.ini file of the `pytorch_live` device ([AndroidEmulatorDeviceInstaller.ts](https://github.com/pytorch/live/blob/main/torchlive-cli/src/installers/android/AndroidEmulatorDeviceInstaller.ts) file).
- The doctor command has also been adapted to this change. Therefore, the check will change depending on the CPU architecture ([Doctor.ts](https://github.com/pytorch/live/blob/main/torchlive-cli/src/cli-commands/Doctor.ts) file).

## **Changelog**

[TORCHLIVE-CLI][SETUP-DEV] - Create an AVD for the M1 Macs (avoids emulator failure)

## Test Plan

After cloning the repository, you can go to the `torchlive-cli` folder, install the NPM packages and run the `setup-dev` command:

```bash
$ cd torchlive-cli
$ npm install
$ npm run start setup-dev
```

Now, if you open Android Studio and go to the AVD Manager, you will see that the column CPU/ABI of the `pytorch live` virtual device will be set according to your CPU architecture.

To really check if the emulator works, initialise a project using `torchlive-cli` and run it with android:

```bash
$ npx torchlive-cli init MyFirstProject
$ cd MyFirstProject
$ npx torchlive-cli run-android
```

After doing this, you can go to the Android Studio AVD Manager and you will see that the size of the `pytorch_live` emulator has a size of 17GB (instead of 1MB) and its CPU/ABI is correctly set to `arm64`:

<img width="782" alt="Screenshot_2022-01-03_at_17 57 13" src="https://user-images.githubusercontent.com/39239895/147962917-9bfd2f62-8fed-4232-952f-6f13c0df3273.png">

## Remarks

### Newer MacBooks identification issue

A way to identify that the current device is a M1 MacBook is executing the following condition:

```jsx
if(os.cpus()[0].model === 'Apple M1') {}
```

However, this only applies to the M1 MacBooks and I could not test this condition on the new M1 Pro & M1 Max MacBooks.